### PR TITLE
Fix `Try it out` section in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The default player implementation uses [Bevy](https://github.com/bevyengine/bevy
 
 ```bash
 cd crates/player
-cargo r --release -- ../../fixtures/ui/confetti.json
+cargo r --release -- --input ../../fixtures/ui/drink.json
 ```
 
 There are some lottie files for demonstration purpose under `fixtures/ui`
@@ -31,7 +31,7 @@ Exporting animation headlessly is also supported, aiming to render animations on
 
 ```bash
 cd crates/player
-cargo r --release -- ../../fixtures/ui/confetti.json --headless
+cargo r --release -- --input ../../fixtures/ui/drink.json --headless
 ```
 
 # Font Loading


### PR DESCRIPTION
I fixed tutorial section in README.

- there is no confetti.json in fixtures/ui. so I changed it to drink.json
- the player requires input option for selecting lottie file.